### PR TITLE
v1.0.1 of default policy. Removed 1 rule, added 8

### DIFF
--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.0.1
 rules:
   - id: credential_modified
     description: Sensitive credential files were modified using a non-standard tool
@@ -47,3 +47,53 @@ rules:
       open.filename =~ "/lib/modules/*" && open.flags & O_CREAT > 0
     tags:
       technique: T1215
+  - id: nsswitch_conf_mod
+    description: Exploits that modify nsswitch.conf to interfere with authentication
+    expression: >-
+      open.filename == "/etc/nsswitch.conf" && open.flags & (O_RDWR | O_WRONLY) > 0
+    tags:
+      technique: T1556
+  - id: pam_modification
+    description: PAM modification
+    expression: >-
+      open.filename =~ "/etc/pam.d/*" && open.flags & (O_RDWR | O_WRONLY) > 0
+    tags:
+      technique: T1556
+  - id: cron_at_job_injection
+    description: Unauthorized scheduling client
+    expression: >-
+      open.filename =~ "/var/spool/cron/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0 &&
+      process.name not in ["at", "crontab"]
+    tags:
+      technique: T1053
+  - id: kernel_modification
+    description: Unauthorized kernel modification
+    expression: >-
+      open.filename =~ "/boot/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
+    tags:
+      technique: T1014
+  - id: systemd_modification
+    description: Unauthorized modification of a service
+    expression: >-
+      open.filename =~ "/lib/systemd/system/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
+    tags:
+      technique: T1014
+  - id: authentication_logs_accessed
+    description: unauthorized file accessing access logs
+    expression: >-
+      open.filename in ["/run/utmp", "/var/run/utmp", "/var/log/wtmp"] &&
+      process.name not in ["login", "sshd", "last", "who", "w", "vminfo"]
+    tags:
+      technique: T1070
+  - id: root_ssh_key
+    description: attempts to create or modify root's SSH key
+    expression: >-
+      open.filename == "/root/.ssh/authorized_keys" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
+    tags:
+      technique: T1556
+  - id: ssl_certificate_tampering
+    description: Tampering with SSL certificates for machine-in-the-middle attacks against OpenSSL
+    expression: >-
+      open.filename =~ "/etc/ssl/certs/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
+    tags:
+      technique: T1338

--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -35,12 +35,6 @@ rules:
       chmod.filename =~ "/var/log/*" || chmod.filename =~ "/usr/lib/*"
     tags:
       technique: T1222
-  - id: hidden_file
-    description: A hidden file was created
-    expression: >-
-      open.basename =~ ".*" && open.flags & O_CREAT > 0
-    tags:
-      technique: T1158
   - id: kernel_module
     description: A new kernel module was added
     expression: >-

--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -94,3 +94,13 @@ rules:
       open.filename =~ "/etc/ssl/certs/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
     tags:
       technique: T1338
+  - id: pci_11_5
+    description: Modification of critical system files
+    expression: >-
+      (open.filename =~ "/bin/*" || 
+      open.filename =~ "/sbin/*" || 
+      open.filename =~ "/usr/bin/*" || 
+      open.filename =~ "/usr/sbin/*" || 
+      open.filename =~ "/opt/*") && 
+      open.flags & (O_RDWR | O_WRONLY) > 0 &&
+      process.name not in ["agent", "security-agent", "system-probe", "process-agent"]

--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -1,11 +1,11 @@
 ---
 version: 1.0.1
 rules:
-  - id: credential_modified
-    description: Sensitive credential files were modified using a non-standard tool
+  - id: credential_accessed
+    description: Sensitive credential files were accessed using a non-standard tool
     expression: >-
       (open.filename == "/etc/shadow" || open.filename == "/etc/gshadow") &&
-      process.name not in ["vipw", "vigr"]
+      process.name not in ["vipw", "vigr", "accounts-daemon"]
     tags:
       technique: T1003
   - id: memory_dump

--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -17,22 +17,25 @@ rules:
   - id: logs_altered
     description: Log data was deleted
     expression: >-
-      (open.filename =~ "/var/log/*" && open.flags & O_TRUNC > 0)
+      (open.filename =~ "/var/log/*" && open.flags & O_TRUNC > 0) &&
+      process.name not in ["agent", "security-agent", "process-agent", "system-probe", "kubelet", "containerd"]
     tags:
       technique: T1070
   - id: logs_removed
     description: Log files were removed
     expression: >-
-      unlink.filename =~ "/var/log/*"
+      unlink.filename =~ "/var/log/*" &&
+      process.name not in ["agent", "security-agent", "process-agent", "system-probe", "kubelet", "containerd"]
     tags:
       technique: T1070
   - id: permissions_changed
     description: Permissions were changed on sensitive files
     expression: >-
-      chmod.filename =~ "/etc/*" || chmod.filename =~ "/etc/*" ||
+      (chmod.filename =~ "/etc/*" || chmod.filename =~ "/etc/*" ||
       chmod.filename =~ "/sbin/*" || chmod.filename =~ "/usr/sbin/*" ||
       chmod.filename =~ "/usr/local/sbin*" || chmod.filename =~ "/usr/bin/local/*" ||
-      chmod.filename =~ "/var/log/*" || chmod.filename =~ "/usr/lib/*"
+      chmod.filename =~ "/var/log/*" || chmod.filename =~ "/usr/lib/*") &&
+      process.name not in ["containerd", "kubelet"]
     tags:
       technique: T1222
   - id: kernel_module


### PR DESCRIPTION
### What does this PR do?

In this PR, I have updated the default policies for the security agent.

Rules removed:
- Hidden File: The hidden file detection has been deemed too noisy. This may be readded at a later date after further research.

Rules added:
- Nsswitch.conf Modification: nsswitch.conf modification from an unusual source process can be an indicator of an exploit attempting to interfere with authentication
- PAM Modification: PAM modification from an unusual source process can be an indicator of an exploit attempting to interfere with authentication
- Cron scheduling from an Unauthorized Client: If cron scheduling occurs from a process other than "at" or "crontab", it could indicate a persistence attempt by an attacker.
- Unauthorized Kernel Modification: Accessing files in /boot/ could indicate an attempt to modify the kernel.
- Systemd Modification: The creation or modification of a service on the host could indicate an attempt to gain persistence.
- Authentication Log Access: Accessing authentication logs from an unusual source process could indicate the attempt to conceal attacker activity
- Create/Modify Root's SSH Key: Creating/Modifying root's SSH key may indicate privilege escalation or an attacker gaining persistence on a host
- SSL Certificate Tampering: Modification of an SSL certificate may indicate an attacker attempting a man-in-the-middle attack against OpenSSL

### Motivation

New threat research leading to more default detections based on FIM data.

### Additional Notes

These rules were checked against security-agent approvers before submitting PR.
