### PR TITLE
Runtime default policy fixes

### DIFF
--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -31,9 +31,9 @@ rules:
   - id: permissions_changed
     description: Permissions were changed on sensitive files
     expression: >-
-      (chmod.filename =~ "/etc/*" || chmod.filename =~ "/etc/*" ||
+      (chmod.filename =~ "/etc/*" ||
       chmod.filename =~ "/sbin/*" || chmod.filename =~ "/usr/sbin/*" ||
-      chmod.filename =~ "/usr/local/sbin*" || chmod.filename =~ "/usr/bin/local/*" ||
+      chmod.filename =~ "/usr/local/sbin/*" || chmod.filename =~ "/usr/local/bin/*" ||
       chmod.filename =~ "/var/log/*" || chmod.filename =~ "/usr/lib/*") &&
       process.name not in ["containerd", "kubelet"]
     tags:
@@ -41,7 +41,7 @@ rules:
   - id: kernel_module
     description: A new kernel module was added
     expression: >-
-      open.filename =~ "/lib/modules/*" && open.flags & O_CREAT > 0
+      (open.filename =~ "/lib/modules/*" || open.filename =~ "/usr/lib/modules/*") && open.flags & O_CREAT > 0
     tags:
       technique: T1215
   - id: nsswitch_conf_mod
@@ -72,7 +72,7 @@ rules:
   - id: systemd_modification
     description: Unauthorized modification of a service
     expression: >-
-      open.filename =~ "/lib/systemd/system/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
+      (open.filename =~ "/lib/systemd/system/*" || open.filename =~ "/usr/lib/systemd/system/*") && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
     tags:
       technique: T1014
   - id: authentication_logs_accessed


### PR DESCRIPTION
### What does this PR do?

Fix a few rules of the default policy:
- permissions_changed: fixed one watched folder from "/usr/bin/local/*" to "/usr/local/bin/*"
- kernel_module: watch both /lib/modules/* /usr/lib/modules/*
- systemd_modification: watch "/usr/lib/systemd/system/*" instead of "/lib/systemd/system/*"

The last 2 changes are required because /lib is now a symlink to /usr/lib. The runtime security agent resolve paths to the symlink target.
