### PR TITLE
Isolate /opt from pci_11_5 rule

### DIFF
--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -94,13 +94,17 @@ rules:
       open.filename =~ "/etc/ssl/certs/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
     tags:
       technique: T1338
-  - id: pci_11_5
+  - id: pci_11_5_bin
     description: Modification of critical system files
     expression: >-
       (open.filename =~ "/bin/*" || 
       open.filename =~ "/sbin/*" || 
       open.filename =~ "/usr/bin/*" || 
-      open.filename =~ "/usr/sbin/*" || 
-      open.filename =~ "/opt/*") && 
+      open.filename =~ "/usr/sbin/*") &&
+      open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
+  - id: pci_11_5_opt
+    description: Modification of critical system files in /opt
+    expression: >-
+      open.filename =~ "/opt/*" &&
       open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0 &&
       process.name not in ["agent", "security-agent", "system-probe", "process-agent", "postgres"]


### PR DESCRIPTION
### What does this PR do?

This PR splits the `pci_11_5` rule to refine the detection rule on the `*bin*` directories.

### Motivation

None of the processes listed in the current rule should be accessing a `*bin*` directory with write access.

### Additional Notes

We need to make sure that the backend rules are modified accordingly.
