### PR TITLE
Default.policy version 1.1.0

### DIFF
--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -95,7 +95,7 @@ rules:
     description: Unauthorized scheduling client
     expression: >-
       open.filename =~ "/var/spool/cron/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0 &&
-      process.name not in ["at", "crontab"]
+      process.filename not in ["/usr/bin/at", "/usr/bin/crontab"]
 
   - id: systemd_modification
     description: Unauthorized modification of a service
@@ -107,7 +107,8 @@ rules:
     description: unauthorized file accessing access logs
     expression: >-
       open.filename in ["/run/utmp", "/var/run/utmp", "/var/log/wtmp"] &&
-      process.name not in ["login", "sshd", "last", "who", "w", "vminfo", "sudo"]
+      process.filename not in ["/usr/bin/login", "/usr/sbin/sshd", "/usr/bin/last", "/usr/bin/who", "/usr/bin/w",
+      "/usr/bin/sudo", "/usr/sbin/cron"]
 
   - id: ssh_authorized_keys
     description: attempts to create or modify an authorized_keys file

--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -9,26 +9,18 @@ macros:
   - id: DD_AGENT_PROCESSES
     description: Processes that are a part of the Datadog Agent
     expression: >-
-      ["/opt/datadog-agent/embedded/bin/agent", "/opt/datadog-agent/embedded/bin/system-probe",
-       "/opt/datadog-agent/embedded/bin/security-agent", "/opt/datadog-agent/embedded/bin/process-agent"]
+      ["/opt/datadog-agent/embedded/bin/agent", "/opt/datadog-agent/embedded/bin/system-probe", "/opt/datadog-agent/embedded/bin/security-agent", "/opt/datadog-agent/embedded/bin/process-agent"]
 
   - id: CONTAINER_PROCESSES
     description: Processes related to operating containers and kubernetes clusters
     expression: >-
-      ["/usr/bin/containerd", "/usr/bin/docker", "/usr/bin/dockerd", "/usr/bin/docker-compose",
-      "/usr/bin/kubelet", "/usr/bin/skydns", "exechealthz", "/usr/local/bin/weave-net", "/opt/cni/bin/loopback", "/opt/cni/bin/bridge", "openshift-sdn", "openshift"]
+      ["/usr/bin/containerd", "/usr/bin/docker", "/usr/bin/dockerd", "/usr/bin/docker-compose", "/usr/bin/kubelet", "/usr/bin/skydns", "exechealthz", "/usr/local/bin/weave-net", "/opt/cni/bin/loopback", "/opt/cni/bin/bridge", "openshift-sdn", "openshift"]
       # TODO: hyperkube, kube2sky, exechealthz, openshift-sdn, openshift
 
   - id: CREDENTIAL_PROCESSES
     desription: Processes that access credential files as part of normal system activity
     expression: >-
-      ["/usr/lib/accountsservice/accounts-daemon", "/usr/bin/login", "/usr/bin/newgrp", "/usr/bin/sg",
-       "/usr/bin/shadowconfig", "/usr/bin/chage", "/usr/bin/chfn", "/usr/bin/chsh", "/usr/sbin/cron", "/usr/bin/expiry",
-       "/usr/bin/gpasswd", "/usr/bin/passwd", "/usr/sbin/chgpasswd", "/usr/sbin/chpasswd", "/usr/sbin/cpgr",
-       "/usr/sbin/cppw", "/usr/sbin/groupadd", "/usr/sbin/groupdel", "/usr/sbin/groupmems", "/usr/sbin/groupmod",
-       "/usr/sbin/grpck", "/usr/sbin/grpconv", "/usr/sbin/grpunconv", "/usr/sbin/newusers", "/usr/sbin/pwck",
-       "/usr/sbin/pwconv", "/usr/sbin/pwunconv", "/usr/bin/sudo", "/usr/sbin/useradd", "/usr/sbin/userdel",
-       "/usr/sbin/usermod", "/usr/sbin/vigr", "/usr/sbin/vipw"]
+      ["/usr/lib/accountsservice/accounts-daemon", "/usr/bin/login", "/usr/bin/newgrp", "/usr/bin/sg", "/usr/bin/shadowconfig", "/usr/bin/chage", "/usr/bin/chfn", "/usr/bin/chsh", "/usr/sbin/cron", "/usr/bin/expiry", "/usr/bin/gpasswd", "/usr/bin/passwd", "/usr/sbin/chgpasswd", "/usr/sbin/chpasswd", "/usr/sbin/cpgr", "/usr/sbin/cppw", "/usr/sbin/groupadd", "/usr/sbin/groupdel", "/usr/sbin/groupmems", "/usr/sbin/groupmod", "/usr/sbin/grpck", "/usr/sbin/grpconv", "/usr/sbin/grpunconv", "/usr/sbin/newusers", "/usr/sbin/pwck", "/usr/sbin/pwconv", "/usr/sbin/pwunconv", "/usr/bin/sudo", "/usr/sbin/useradd", "/usr/sbin/userdel", "/usr/sbin/usermod", "/usr/sbin/vigr", "/usr/sbin/vipw"]
 
 # Add allow-listed process filenames to this list. Uncomment to use.
 # Add to rules in order to apply this allow list.
@@ -79,8 +71,7 @@ rules:
     description: Unauthorized kernel modification
     expression: >-
       open.filename =~ "/boot/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
-      && process.filename not in ["/usr/bin/dpkg", "/usr/sbin/grub-mkconfig", "/usr/sbin/mkinitramfs",
-         "/usr/libexec/fwupd/fwupd"]
+      && process.filename not in ["/usr/bin/dpkg", "/usr/sbin/grub-mkconfig", "/usr/sbin/mkinitramfs", "/usr/libexec/fwupd/fwupd"]
 
   - id: nsswitch_conf_mod
     description: Exploits that modify nsswitch.conf to interfere with authentication
@@ -108,8 +99,7 @@ rules:
     description: unauthorized file accessing access logs
     expression: >-
       open.filename in ["/run/utmp", "/var/run/utmp", "/var/log/wtmp"] &&
-      process.filename not in ["/usr/bin/login", "/usr/sbin/sshd", "/usr/bin/last", "/usr/bin/who", "/usr/bin/w",
-      "/usr/bin/sudo", "/usr/sbin/cron"]
+      process.filename not in ["/usr/bin/login", "/usr/sbin/sshd", "/usr/bin/last", "/usr/bin/who", "/usr/bin/w", "/usr/bin/sudo", "/usr/sbin/cron"]
 
   - id: ssh_authorized_keys
     description: attempts to create or modify an authorized_keys file

--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -14,7 +14,7 @@ macros:
 # These processes are related to operating containers and kubernetes clusters
   - id: CONTAINER_PROCESSES
     expression: >-
-      ["containerd", "docker", "dockerd", "exe", "docker-compose", "docker-entrypoi", "docker-runc-cur", "docker-current", "dockerd-current", 
+      ["containerd", "docker", "dockerd", "exe", "docker-compose", "docker-runc-cur", "docker-current", "dockerd-current", 
       "kueblet", "hyperkube", "skydns", "kube2sky", "exechealthz", "weave-net", "loopback", "bridge", "openshift-sdn", "openshift"]
   
 # These are processes that regularly access credential files as part of normal system activity. Add or remove as appropriate.

--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -17,13 +17,17 @@ macros:
     expression: >-
       ["containerd", "docker", "dockerd", "exe", "docker-compose", "docker-current", "dockerd-current", 
       "kueblet", "hyperkube", "skydns", "kube2sky", "exechealthz", "weave-net", "loopback", "bridge", "openshift-sdn", "openshift"]
-  
-# These are processes that regularly access credential files as part of normal system activity. Add or remove as appropriate.
+
   - id: CREDENTIAL_PROCESSES
+    desription: Processes that access credential files as part of normal system activity
     expression: >-
-      ["accounts-daemon", "login", "newgrp", "sg", "sbin", "shadowconfig", "chage", "chfn", "chsh", "cron", "expiry", "gpasswd", "passwd", 
-      "chgpasswd", "chpasswd", "cpgr", "cppw", "groupadd", "groupdel", "groupmems", "groupmod", "grpck", "grpconv", "grpunconv", 
-      "newusers", "pwck", "pwconv", "pwunconv", "sudo", "useradd", "userdel", "usermod", "vigr", "vipw"]
+      ["/usr/lib/accountsservice/accounts-daemon", "/usr/bin/login", "/usr/bin/newgrp", "/usr/bin/sg",
+       "/usr/bin/shadowconfig", "/usr/bin/chage", "/usr/bin/chfn", "/usr/bin/chsh", "/usr/sbin/cron", "/usr/bin/expiry",
+       "/usr/bin/gpasswd", "/usr/bin/passwd", "/usr/sbin/chgpasswd", "/usr/sbin/chpasswd", "/usr/sbin/cpgr",
+       "/usr/sbin/cppw", "/usr/sbin/groupadd", "/usr/sbin/groupdel", "/usr/sbin/groupmems", "/usr/sbin/groupmod",
+       "/usr/sbin/grpck", "/usr/sbin/grpconv", "/usr/sbin/grpunconv", "/usr/sbin/newusers", "/usr/sbin/pwck",
+       "/usr/sbin/pwconv", "/usr/sbin/pwunconv", "/usr/bin/sudo", "/usr/sbin/useradd", "/usr/sbin/userdel",
+       "/usr/sbin/usermod", "/usr/sbin/vigr", "/usr/sbin/vipw"]
 
 # Add allow-listed process names to this list. Uncomment to use.
 # Add to rules in order to apply this allow list.
@@ -39,7 +43,7 @@ rules:
     description: Sensitive credential files were accessed using a non-standard tool
     expression: >-
       (open.filename == "/etc/shadow" || open.filename == "/etc/gshadow") &&
-      process.name not in CREDENTIAL_PROCESSES
+      process.filename not in CREDENTIAL_PROCESSES
   
   - id: logs_altered
     description: Log data was deleted

--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -72,6 +72,14 @@ rules:
     description: A new kernel module was added
     expression: >-
       (open.filename =~ "/lib/modules/*" || open.filename =~ "/usr/lib/modules/*") && open.flags & O_CREAT > 0
+      && process.filename not in ["/usr/bin/dpkg"]
+
+  - id: kernel_modification
+    description: Unauthorized kernel modification
+    expression: >-
+      open.filename =~ "/boot/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
+      && process.filename not in ["/usr/bin/dpkg", "/usr/sbin/grub-mkconfig", "/usr/sbin/mkinitramfs",
+         "/usr/libexec/fwupd/fwupd"]
 
   - id: nsswitch_conf_mod
     description: Exploits that modify nsswitch.conf to interfere with authentication
@@ -88,11 +96,6 @@ rules:
     expression: >-
       open.filename =~ "/var/spool/cron/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0 &&
       process.name not in ["at", "crontab"]
-
-  - id: kernel_modification
-    description: Unauthorized kernel modification
-    expression: >-
-      open.filename =~ "/boot/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
 
   - id: systemd_modification
     description: Unauthorized modification of a service

--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -40,11 +40,6 @@ rules:
       (open.filename == "/etc/shadow" || open.filename == "/etc/gshadow") &&
       process.name not in CREDENTIAL_PROCESSES
   
-  - id: memory_dump
-    description: Potential memory dump
-    expression: >-
-      open.filename =~ "/proc/*" && open.basename in ["maps", "mem"]
-  
   - id: logs_altered
     description: Log data was deleted
     expression: >-

--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -49,14 +49,14 @@ rules:
     description: Log data was deleted
     expression: >-
       (open.filename =~ "/var/log/*" && open.flags & O_TRUNC > 0)
-      && ((open.filename !~ "/var/log/datadog-agent/*" && process.filename not in DD_AGENT_PROCESSES)
+      && ((open.filename !~ "/var/log/datadog/*" && process.filename not in DD_AGENT_PROCESSES)
            || process.name not in CONTAINER_PROCESSES))
 
   - id: logs_removed
     description: Log files were removed
     expression: >-
       unlink.filename =~ "/var/log/*"
-      && ((unlink.filename !~ "/var/log/datadog-agent/*" && process.filename not in DD_AGENT_PROCESSES)
+      && ((unlink.filename !~ "/var/log/datadog/*" && process.filename not in DD_AGENT_PROCESSES)
            || process.name not in CONTAINER_PROCESSES))
 
   - id: permissions_changed

--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -14,7 +14,7 @@ macros:
 # These processes are related to operating containers and kubernetes clusters
   - id: CONTAINER_PROCESSES
     expression: >-
-      ["containerd", "docker", "dockerd", "exe", "docker-compose", "docker-runc-cur", "docker-current", "dockerd-current", 
+      ["containerd", "docker", "dockerd", "exe", "docker-compose", "docker-current", "dockerd-current", 
       "kueblet", "hyperkube", "skydns", "kube2sky", "exechealthz", "weave-net", "loopback", "bridge", "openshift-sdn", "openshift"]
   
 # These are processes that regularly access credential files as part of normal system activity. Add or remove as appropriate.

--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -12,11 +12,12 @@ macros:
       ["/opt/datadog-agent/embedded/bin/agent", "/opt/datadog-agent/embedded/bin/system-probe",
        "/opt/datadog-agent/embedded/bin/security-agent", "/opt/datadog-agent/embedded/bin/process-agent"]
 
-# These processes are related to operating containers and kubernetes clusters
   - id: CONTAINER_PROCESSES
+    description: Processes related to operating containers and kubernetes clusters
     expression: >-
-      ["containerd", "docker", "dockerd", "exe", "docker-compose", "docker-current", "dockerd-current", 
-      "kueblet", "hyperkube", "skydns", "kube2sky", "exechealthz", "weave-net", "loopback", "bridge", "openshift-sdn", "openshift"]
+      ["/usr/bin/containerd", "/usr/bin/docker", "/usr/bin/dockerd", "/usr/bin/docker-compose",
+      "/usr/bin/kubelet", "/usr/bin/skydns", "exechealthz", "/usr/local/bin/weave-net", "/opt/cni/bin/loopback", "/opt/cni/bin/bridge", "openshift-sdn", "openshift"]
+      # TODO: hyperkube, kube2sky, exechealthz, openshift-sdn, openshift
 
   - id: CREDENTIAL_PROCESSES
     desription: Processes that access credential files as part of normal system activity
@@ -50,14 +51,14 @@ rules:
     expression: >-
       (open.filename =~ "/var/log/*" && open.flags & O_TRUNC > 0)
       && ((open.filename !~ "/var/log/datadog/*" && process.filename not in DD_AGENT_PROCESSES)
-           || process.name not in CONTAINER_PROCESSES))
+           || process.filename not in CONTAINER_PROCESSES))
 
   - id: logs_removed
     description: Log files were removed
     expression: >-
       unlink.filename =~ "/var/log/*"
       && ((unlink.filename !~ "/var/log/datadog/*" && process.filename not in DD_AGENT_PROCESSES)
-           || process.name not in CONTAINER_PROCESSES))
+           || process.filename not in CONTAINER_PROCESSES))
 
   - id: permissions_changed
     description: Permissions were changed on sensitive files
@@ -66,7 +67,7 @@ rules:
       chmod.filename =~ "/sbin/*" || chmod.filename =~ "/usr/sbin/*" ||
       chmod.filename =~ "/usr/local/sbin/*" || chmod.filename =~ "/usr/local/bin/*" ||
       chmod.filename =~ "/var/log/*" || chmod.filename =~ "/usr/lib/*") &&
-      process.name not in CONTAINER_PROCESSES
+      process.filename not in CONTAINER_PROCESSES
 
   - id: kernel_module
     description: A new kernel module was added

--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -109,10 +109,11 @@ rules:
       open.filename in ["/run/utmp", "/var/run/utmp", "/var/log/wtmp"] &&
       process.name not in ["login", "sshd", "last", "who", "w", "vminfo", "sudo"]
 
-  - id: root_ssh_key
-    description: attempts to create or modify root's SSH key
+  - id: ssh_authorized_keys
+    description: attempts to create or modify an authorized_keys file
     expression: >-
-      open.filename == "/root/.ssh/authorized_keys" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
+      (open.filename =~ "/root/.ssh/" || open.filename =~ "/home/*") && open.basename == "authorized_keys"
+       && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
 
   - id: ssl_certificate_tampering
     description: Tampering with SSL certificates for machine-in-the-middle attacks against OpenSSL

--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -24,11 +24,6 @@ macros:
       "chgpasswd", "chpasswd", "cpgr", "cppw", "groupadd", "groupdel", "groupmems", "groupmod", "grpck", "grpconv", "grpunconv", 
       "newusers", "pwck", "pwconv", "pwunconv", "sudo", "useradd", "userdel", "usermod", "vigr", "vipw"]
 
-# These are common database processes. Add or remove as appropriate
-  - id: DB_PROCESSES
-    expression: >-
-      ["mysqld", "postgres", "elasticsearch", "mongod"]
-
 # Add allow-listed process names to this list. Uncomment to use.
 # Add to rules in order to apply this allow list.
 #  - id: ALLOWED_PROCESSES
@@ -127,10 +122,3 @@ rules:
       open.filename =~ "/usr/bin/*" || 
       open.filename =~ "/usr/sbin/*") &&
       open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
-  
-  - id: pci_11_5_critical_files
-    description: Modification of critical system files in /opt
-    expression: >-
-      open.filename =~ "/opt/*" &&
-      open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0 &&
-      (process.name not in DD_AGENT_PROCESSES && process.name not in DB_PROCESSES)

--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -44,21 +44,21 @@ rules:
     expression: >-
       (open.filename == "/etc/shadow" || open.filename == "/etc/gshadow") &&
       process.filename not in CREDENTIAL_PROCESSES
-  
+
   - id: logs_altered
     description: Log data was deleted
     expression: >-
       (open.filename =~ "/var/log/*" && open.flags & O_TRUNC > 0)
       && ((open.filename !~ "/var/log/datadog-agent/*" && process.filename not in DD_AGENT_PROCESSES)
            || process.name not in CONTAINER_PROCESSES))
-  
+
   - id: logs_removed
     description: Log files were removed
     expression: >-
       unlink.filename =~ "/var/log/*"
       && ((unlink.filename !~ "/var/log/datadog-agent/*" && process.filename not in DD_AGENT_PROCESSES)
            || process.name not in CONTAINER_PROCESSES))
-  
+
   - id: permissions_changed
     description: Permissions were changed on sensitive files
     expression: >-
@@ -67,60 +67,60 @@ rules:
       chmod.filename =~ "/usr/local/sbin/*" || chmod.filename =~ "/usr/local/bin/*" ||
       chmod.filename =~ "/var/log/*" || chmod.filename =~ "/usr/lib/*") &&
       process.name not in CONTAINER_PROCESSES
-  
+
   - id: kernel_module
     description: A new kernel module was added
     expression: >-
       (open.filename =~ "/lib/modules/*" || open.filename =~ "/usr/lib/modules/*") && open.flags & O_CREAT > 0
-  
+
   - id: nsswitch_conf_mod
     description: Exploits that modify nsswitch.conf to interfere with authentication
     expression: >-
       open.filename == "/etc/nsswitch.conf" && open.flags & (O_RDWR | O_WRONLY) > 0
-  
+
   - id: pam_modification
     description: PAM modification
     expression: >-
       open.filename =~ "/etc/pam.d/*" && open.flags & (O_RDWR | O_WRONLY) > 0
-  
+
   - id: cron_at_job_injection
     description: Unauthorized scheduling client
     expression: >-
       open.filename =~ "/var/spool/cron/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0 &&
       process.name not in ["at", "crontab"]
-  
+
   - id: kernel_modification
     description: Unauthorized kernel modification
     expression: >-
       open.filename =~ "/boot/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
-  
+
   - id: systemd_modification
     description: Unauthorized modification of a service
     expression: >-
-      (open.filename =~ "/lib/systemd/system/*" || open.filename =~ "/usr/lib/systemd/system/*") && 
+      (open.filename =~ "/lib/systemd/system/*" || open.filename =~ "/usr/lib/systemd/system/*") &&
       open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
-  
+
   - id: authentication_logs_accessed
     description: unauthorized file accessing access logs
     expression: >-
       open.filename in ["/run/utmp", "/var/run/utmp", "/var/log/wtmp"] &&
       process.name not in ["login", "sshd", "last", "who", "w", "vminfo", "sudo"]
-  
+
   - id: root_ssh_key
     description: attempts to create or modify root's SSH key
     expression: >-
       open.filename == "/root/.ssh/authorized_keys" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
-  
+
   - id: ssl_certificate_tampering
     description: Tampering with SSL certificates for machine-in-the-middle attacks against OpenSSL
     expression: >-
       open.filename =~ "/etc/ssl/certs/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
-  
+
   - id: pci_11_5_critical_binaries
     description: Modification of critical binary files
     expression: >-
-      (open.filename =~ "/bin/*" || 
-      open.filename =~ "/sbin/*" || 
-      open.filename =~ "/usr/bin/*" || 
+      (open.filename =~ "/bin/*" ||
+      open.filename =~ "/sbin/*" ||
+      open.filename =~ "/usr/bin/*" ||
       open.filename =~ "/usr/sbin/*") &&
       open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0

--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -14,8 +14,7 @@ macros:
   - id: CONTAINER_PROCESSES
     description: Processes related to operating containers and kubernetes clusters
     expression: >-
-      ["/usr/bin/containerd", "/usr/bin/docker", "/usr/bin/dockerd", "/usr/bin/docker-compose", "/usr/bin/kubelet", "/usr/bin/skydns", "exechealthz", "/usr/local/bin/weave-net", "/opt/cni/bin/loopback", "/opt/cni/bin/bridge", "openshift-sdn", "openshift"]
-      # TODO: hyperkube, kube2sky, exechealthz, openshift-sdn, openshift
+      ["/usr/bin/containerd", "/usr/bin/docker", "/usr/bin/dockerd", "/usr/bin/docker-compose", "/usr/bin/kubelet", "/usr/bin/skydns", "/usr/bin/exechealthz", "/usr/local/bin/weave-net", "/opt/cni/bin/loopback", "/opt/cni/bin/bridge"]
 
   - id: CREDENTIAL_PROCESSES
     desription: Processes that access credential files as part of normal system activity
@@ -42,15 +41,13 @@ rules:
     description: Log data was deleted
     expression: >-
       (open.filename =~ "/var/log/*" && open.flags & O_TRUNC > 0)
-      && ((open.filename !~ "/var/log/datadog/*" && process.filename not in DD_AGENT_PROCESSES)
-           || process.filename not in CONTAINER_PROCESSES))
+      && ((open.filename !~ "/var/log/datadog/*" && process.filename not in DD_AGENT_PROCESSES) || process.filename not in CONTAINER_PROCESSES)
 
   - id: logs_removed
     description: Log files were removed
     expression: >-
       unlink.filename =~ "/var/log/*"
-      && ((unlink.filename !~ "/var/log/datadog/*" && process.filename not in DD_AGENT_PROCESSES)
-           || process.filename not in CONTAINER_PROCESSES))
+      && ((unlink.filename !~ "/var/log/datadog/*" && process.filename not in DD_AGENT_PROCESSES) || process.filename not in CONTAINER_PROCESSES)
 
   - id: permissions_changed
     description: Permissions were changed on sensitive files
@@ -104,8 +101,7 @@ rules:
   - id: ssh_authorized_keys
     description: attempts to create or modify an authorized_keys file
     expression: >-
-      (open.filename =~ "/root/.ssh/" || open.filename =~ "/home/*") && open.basename == "authorized_keys"
-       && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
+      (open.filename =~ "/root/.ssh/*" || open.filename =~ "/home/*") && open.basename == "authorized_keys"  && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
 
   - id: ssl_certificate_tampering
     description: Tampering with SSL certificates for machine-in-the-middle attacks against OpenSSL

--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -130,3 +130,4 @@ rules:
       open.filename =~ "/usr/bin/*" ||
       open.filename =~ "/usr/sbin/*") &&
       open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
+      && process.filename not in ["/usr/bin/containerd", "/usr/bin/dpkg"]

--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -92,7 +92,7 @@ rules:
     expression: >-
       open.filename =~ "/etc/pam.d/*" && open.flags & (O_RDWR | O_WRONLY | O_CREAT) > 0
 
-  - id: cron_at_job_injection
+  - id: cron_at_job_creation
     description: Unauthorized scheduling client
     expression: >-
       open.filename =~ "/var/spool/cron/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0 &&

--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -29,11 +29,11 @@ macros:
        "/usr/sbin/pwconv", "/usr/sbin/pwunconv", "/usr/bin/sudo", "/usr/sbin/useradd", "/usr/sbin/userdel",
        "/usr/sbin/usermod", "/usr/sbin/vigr", "/usr/sbin/vipw"]
 
-# Add allow-listed process names to this list. Uncomment to use.
+# Add allow-listed process filenames to this list. Uncomment to use.
 # Add to rules in order to apply this allow list.
 #  - id: ALLOWED_PROCESSES
 #    expression: >-
-#      process.name not in ["example"]
+#      process.filename not in ["/usr/bin/example"]
 
 ################################################################
 # Rules determine what the Datadog security-agent will monitor.#

--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -6,10 +6,11 @@ version: 1.1.0
 # Macros are used within rules. Macros do not monitor alone.    #
 #################################################################
 macros:
-# These processes are a part of the Datadog Agent
   - id: DD_AGENT_PROCESSES
+    description: Processes that are a part of the Datadog Agent
     expression: >-
-      ["agent", "system-probe", "security-agent", "process-agent"] 
+      ["/opt/datadog-agent/embedded/bin/agent", "/opt/datadog-agent/embedded/bin/system-probe",
+       "/opt/datadog-agent/embedded/bin/security-agent", "/opt/datadog-agent/embedded/bin/process-agent"]
 
 # These processes are related to operating containers and kubernetes clusters
   - id: CONTAINER_PROCESSES
@@ -43,14 +44,16 @@ rules:
   - id: logs_altered
     description: Log data was deleted
     expression: >-
-      (open.filename =~ "/var/log/*" && open.flags & O_TRUNC > 0) &&
-      (process.name not in DD_AGENT_PROCESSES && process.name not in CONTAINER_PROCESSES)
+      (open.filename =~ "/var/log/*" && open.flags & O_TRUNC > 0)
+      && ((open.filename !~ "/var/log/datadog-agent/*" && process.filename not in DD_AGENT_PROCESSES)
+           || process.name not in CONTAINER_PROCESSES))
   
   - id: logs_removed
     description: Log files were removed
     expression: >-
-      unlink.filename =~ "/var/log/*" &&
-      (process.name not in DD_AGENT_PROCESSES && process.name not in CONTAINER_PROCESSES)
+      unlink.filename =~ "/var/log/*"
+      && ((unlink.filename !~ "/var/log/datadog-agent/*" && process.filename not in DD_AGENT_PROCESSES)
+           || process.name not in CONTAINER_PROCESSES))
   
   - id: permissions_changed
     description: Permissions were changed on sensitive files

--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -1,25 +1,67 @@
 ---
-version: 1.0.2
+version: 1.1.0
+
+#################################################################
+# Macros are a way to define reusable expressions and/or lists. #
+# Macros are used within rules. Macros do not monitor alone.    #
+#################################################################
+macros:
+# These processes are a part of the Datadog Agent
+  - id: DD_AGENT_PROCESSES
+    expression: >-
+      ["agent", "system-probe", "security-agent", "process-agent"] 
+
+# These processes are related to operating containers and kubernetes clusters
+  - id: CONTAINER_PROCESSES
+    expression: >-
+      ["containerd", "docker", "dockerd", "exe", "docker-compose", "docker-entrypoi", "docker-runc-cur", "docker-current", "dockerd-current", 
+      "kueblet", "hyperkube", "skydns", "kube2sky", "exechealthz", "weave-net", "loopback", "bridge", "openshift-sdn", "openshift"]
+  
+# These are processes that regularly access credential files as part of normal system activity. Add or remove as appropriate.
+  - id: CREDENTIAL_PROCESSES
+    expression: >-
+      ["accounts-daemon", "login", "newgrp", "sg", "sbin", "shadowconfig", "chage", "chfn", "chsh", "cron", "expiry", "gpasswd", "passwd", 
+      "chgpasswd", "chpasswd", "cpgr", "cppw", "groupadd", "groupdel", "groupmems", "groupmod", "grpck", "grpconv", "grpunconv", 
+      "newusers", "pwck", "pwconv", "pwunconv", "sudo", "useradd", "userdel", "usermod", "vigr", "vipw"]
+
+# These are common database processes. Add or remove as appropriate
+  - id: DB_PROCESSES
+    expression: >-
+      ["mysqld", "postgres", "elasticsearch", "mongod"]
+
+# Add allow-listed process names to this list. Uncomment to use.
+# Add to rules in order to apply this allow list.
+#  - id: ALLOWED_PROCESSES
+#    expression: >-
+#      process.name not in ["example"]
+
+################################################################
+# Rules determine what the Datadog security-agent will monitor.#
+################################################################
 rules:
   - id: credential_accessed
     description: Sensitive credential files were accessed using a non-standard tool
     expression: >-
       (open.filename == "/etc/shadow" || open.filename == "/etc/gshadow") &&
-      process.name not in ["vipw", "vigr", "accounts-daemon", "sudo", "cron"]
+      process.name not in CREDENTIAL_PROCESSES
+  
   - id: memory_dump
     description: Potential memory dump
     expression: >-
       open.filename =~ "/proc/*" && open.basename in ["maps", "mem"]
+  
   - id: logs_altered
     description: Log data was deleted
     expression: >-
       (open.filename =~ "/var/log/*" && open.flags & O_TRUNC > 0) &&
-      process.name not in ["agent", "security-agent", "process-agent", "system-probe", "kubelet", "containerd"]
+      (process.name not in DD_AGENT_PROCESSES && process.name not in CONTAINER_PROCESSES)
+  
   - id: logs_removed
     description: Log files were removed
     expression: >-
       unlink.filename =~ "/var/log/*" &&
-      process.name not in ["agent", "security-agent", "process-agent", "system-probe", "kubelet", "containerd"]
+      (process.name not in DD_AGENT_PROCESSES && process.name not in CONTAINER_PROCESSES)
+  
   - id: permissions_changed
     description: Permissions were changed on sensitive files
     expression: >-
@@ -27,45 +69,56 @@ rules:
       chmod.filename =~ "/sbin/*" || chmod.filename =~ "/usr/sbin/*" ||
       chmod.filename =~ "/usr/local/sbin/*" || chmod.filename =~ "/usr/local/bin/*" ||
       chmod.filename =~ "/var/log/*" || chmod.filename =~ "/usr/lib/*") &&
-      process.name not in ["containerd", "kubelet"]
+      process.name not in CONTAINER_PROCESSES
+  
   - id: kernel_module
     description: A new kernel module was added
     expression: >-
       (open.filename =~ "/lib/modules/*" || open.filename =~ "/usr/lib/modules/*") && open.flags & O_CREAT > 0
+  
   - id: nsswitch_conf_mod
     description: Exploits that modify nsswitch.conf to interfere with authentication
     expression: >-
       open.filename == "/etc/nsswitch.conf" && open.flags & (O_RDWR | O_WRONLY) > 0
+  
   - id: pam_modification
     description: PAM modification
     expression: >-
       open.filename =~ "/etc/pam.d/*" && open.flags & (O_RDWR | O_WRONLY) > 0
+  
   - id: cron_at_job_injection
     description: Unauthorized scheduling client
     expression: >-
       open.filename =~ "/var/spool/cron/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0 &&
       process.name not in ["at", "crontab"]
+  
   - id: kernel_modification
     description: Unauthorized kernel modification
     expression: >-
       open.filename =~ "/boot/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
+  
   - id: systemd_modification
     description: Unauthorized modification of a service
     expression: >-
-      (open.filename =~ "/lib/systemd/system/*" || open.filename =~ "/usr/lib/systemd/system/*") && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
+      (open.filename =~ "/lib/systemd/system/*" || open.filename =~ "/usr/lib/systemd/system/*") && 
+      open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
+  
   - id: authentication_logs_accessed
     description: unauthorized file accessing access logs
     expression: >-
       open.filename in ["/run/utmp", "/var/run/utmp", "/var/log/wtmp"] &&
       process.name not in ["login", "sshd", "last", "who", "w", "vminfo", "sudo"]
+  
   - id: root_ssh_key
     description: attempts to create or modify root's SSH key
     expression: >-
       open.filename == "/root/.ssh/authorized_keys" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
+  
   - id: ssl_certificate_tampering
     description: Tampering with SSL certificates for machine-in-the-middle attacks against OpenSSL
     expression: >-
       open.filename =~ "/etc/ssl/certs/*" && open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
+  
   - id: pci_11_5_critical_binaries
     description: Modification of critical binary files
     expression: >-
@@ -74,9 +127,10 @@ rules:
       open.filename =~ "/usr/bin/*" || 
       open.filename =~ "/usr/sbin/*") &&
       open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0
+  
   - id: pci_11_5_critical_files
     description: Modification of critical system files in /opt
     expression: >-
       open.filename =~ "/opt/*" &&
       open.flags & (O_CREAT | O_RDWR | O_WRONLY) > 0 &&
-      process.name not in ["agent", "security-agent", "system-probe", "process-agent", "postgres"]
+      (process.name not in DD_AGENT_PROCESSES && process.name not in DB_PROCESSES)

--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -89,7 +89,7 @@ rules:
   - id: pam_modification
     description: PAM modification
     expression: >-
-      open.filename =~ "/etc/pam.d/*" && open.flags & (O_RDWR | O_WRONLY) > 0
+      open.filename =~ "/etc/pam.d/*" && open.flags & (O_RDWR | O_WRONLY | O_CREAT) > 0
 
   - id: cron_at_job_injection
     description: Unauthorized scheduling client


### PR DESCRIPTION
### What does this PR do?
The newest update of the security agent policy! This update includes:

- Macros! Macros are available in the security-agent policy language. The are reusable components of the same language used to express rules. Use them to create allow-lists, re-use partial expressions, and more!
- Better signal:noise ratio for existing rules: We've identified standard system activity across our rule-set, and have introduced allow-lists of processes to tune out that activity. Defined as macros, we have lists for standard container processes, system credential processes, and of course, common Datadog Agent processes.
- Improvements to existing rules: Additionally we've tweaked the existing rules to fine more suspicious activity, and better help you maintain compliance

### Motivation
Continuous improvement!

### Additional Notes

Anything else we should know when reviewing?
