### PR TITLE
Remove \n from rule condition

### DIFF
--- a/compliance/containers/cis-docker-1.2.0.yaml
+++ b/compliance/containers/cis-docker-1.2.0.yaml
@@ -407,8 +407,7 @@ rules:
     resources:
       - docker:
           kind: container
-        condition: docker.template("{{ range $k, $_ := $.NetworkSettings.Ports }}{{ with $p := (regexReplaceAllLiteral \"/.*\" ($k | toString) \"\") | atoi }}{{ if lt $p 1024}}failed{{ end }}{{ end }}{{
-          end }}") == ""
+        condition: docker.template("{{ range $k, $_ := $.NetworkSettings.Ports }}{{ with $p := (regexReplaceAllLiteral \"/.*\" ($k | toString) \"\") | atoi }}{{ if lt $p 1024}}failed{{ end }}{{ end }}{{ end }}") == ""
   - id: cis-docker-1.2.0-5.9
     description: '[CIS Docker] Ensure that the host''s network namespace is not shared'
     scope:


### PR DESCRIPTION
### What does this PR do?

Removes `\n` from rule condition. 

### Motivation

I came across this while modifying the rule in `security-monitoring` repo. I actually don't know if the grammar supports having `\n` inside the condition. If it does please ignore my PR. 

### Additional Notes

Anything else we should know when reviewing?
