### PR TITLE
Split check policies actions to increase clarity

### DIFF
--- a/.github/workflows/runtime.yaml
+++ b/.github/workflows/runtime.yaml
@@ -18,5 +18,6 @@ jobs:
           docker run -v `pwd`/runtime:/policies datadog/agent-dev:master /opt/datadog-agent/embedded/bin/security-agent runtime check-policies --policies-dir /policies
 
       - name: Check the policies - datadog/agent:7
+        if: ${{ always() }}
         run: |
           docker run -v `pwd`/runtime:/policies datadog/agent:7 /opt/datadog-agent/embedded/bin/security-agent runtime check-policies --policies-dir /policies

--- a/.github/workflows/runtime.yaml
+++ b/.github/workflows/runtime.yaml
@@ -13,7 +13,10 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v1
 
-      - name: Check the policies
+      - name: Check the policies - datadog/agent-dev:master
         run: |
           docker run -v `pwd`/runtime:/policies datadog/agent-dev:master /opt/datadog-agent/embedded/bin/security-agent runtime check-policies --policies-dir /policies
+
+      - name: Check the policies - datadog/agent:7
+        run: |
           docker run -v `pwd`/runtime:/policies datadog/agent:7 /opt/datadog-agent/embedded/bin/security-agent runtime check-policies --policies-dir /policies


### PR DESCRIPTION
### What does this PR do?

This PR splits the check policies Github Action into two so that it's clearer on which version of the agent the check is failing.

The `if: ${{ always() }}` is used so that the second step is always run, even if the first failed.

### Motivation

Currently the two checks are done in the same step so when one is failing it fails the whole step and you need to look at the logs to figure out what is happening. With this PR the check if first done on the current development version of the agent then on the last release, in two separate steps.
