### PR TITLE
fix resource type kubernetes

### DIFF
--- a/compliance/containers/cis-kubernetes-1.5.1.yaml
+++ b/compliance/containers/cis-kubernetes-1.5.1.yaml
@@ -808,6 +808,7 @@ rules:
     scope:
       - kubernetesNode
     hostSelector: node.label("kubernetes.io/role") == "master"
+    resourceType: kubernetes_master_node
     resources:
       - process:
           name: kube-controller-manager
@@ -824,6 +825,7 @@ rules:
     scope:
       - kubernetesNode
     hostSelector: node.label("kubernetes.io/role") == "master"
+    resourceType: kubernetes_master_node
     resources:
       - process:
           name: kube-controller-manager


### PR DESCRIPTION
### What does this PR do?
It seems resourceType field was missing for 2 rules cis-kubernetes-1.5.1-1.3.2 and cis-kubernetes-1.5.1-1.3.3, leading to an incorrect resource type name (kubernetes_node) being used. So I added the missing fields

### Motivation
Issue spotted with the resource name

### Additional Notes

Anything else we should know when reviewing?
