### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,12 +13,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Create Compliance Benchmarks ConfigMap
-        uses: steebchen/kubectl@v2
+        uses: steebchen/kubectl@v2.0.0
         with:
           command: create configmap datadog-compliance-benchmarks --dry-run -o yaml --from-file=./compliance/containers > ./datadog-compliance-benchmarks.yaml
 
       - name: Create Runtime Security Policies ConfigMap
-        uses: steebchen/kubectl@v2
+        uses: steebchen/kubectl@v2.0.0
         with:
           command: create configmap datadog-runtime-policies --dry-run -o yaml --from-file=./runtime > ./datadog-runtime-policies.yaml
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,11 +22,15 @@ jobs:
         with:
           command: create configmap datadog-runtime-policies --dry-run=client -o yaml --from-file=./runtime > ./datadog-runtime-policies.yaml
 
+      - name: Extract Tag name
+        id: tag_name_extractor
+        run: echo ::set-output name=TAG_NAME::${GITHUB_REF/refs\/tags\//}
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         id: create_release
         with:
-          name: Release ${{ github.ref }}
+          name: Release ${{ steps.tag_name_extractor.outputs.TAG_NAME }}
           body: |
             Changes in this Release
             - Updated compliance benchmarks and runtime security policies for Datadog Security Agent.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,9 @@
 name: Release Security Agent Policies
 
 on:
-  push #:
-    #    tags:
-    #  - 'v*'
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   release:
@@ -15,12 +15,12 @@ jobs:
       - name: Create Compliance Benchmarks ConfigMap
         uses: steebchen/kubectl@v2.0.0
         with:
-          command: create configmap datadog-compliance-benchmarks --dry-run -o yaml --from-file=./compliance/containers > ./datadog-compliance-benchmarks.yaml
+          command: create configmap datadog-compliance-benchmarks --dry-run=client -o yaml --from-file=./compliance/containers > ./datadog-compliance-benchmarks.yaml
 
       - name: Create Runtime Security Policies ConfigMap
         uses: steebchen/kubectl@v2.0.0
         with:
-          command: create configmap datadog-runtime-policies --dry-run -o yaml --from-file=./runtime > ./datadog-runtime-policies.yaml
+          command: create configmap datadog-runtime-policies --dry-run=client -o yaml --from-file=./runtime > ./datadog-runtime-policies.yaml
 
       - name: Create Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,62 +1,37 @@
 name: Release Security Agent Policies
 
 on:
-  push:
-    tags:
-      - 'v*'
+  push #:
+    #    tags:
+    #  - 'v*'
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Create Compliance Benchmarks ConfigMap
+        uses: steebchen/kubectl@v2
+        with:
+          command: create configmap datadog-compliance-benchmarks --dry-run -o yaml --from-file=./compliance/containers > ./datadog-compliance-benchmarks.yaml
+
+      - name: Create Runtime Security Policies ConfigMap
+        uses: steebchen/kubectl@v2
+        with:
+          command: create configmap datadog-runtime-policies --dry-run -o yaml --from-file=./runtime > ./datadog-runtime-policies.yaml
 
       - name: Create Release
+        uses: softprops/action-gh-release@v1
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          name: Release ${{ github.ref }}
           body: |
             Changes in this Release
             - Updated compliance benchmarks and runtime security policies for Datadog Security Agent.
           draft: false
           prerelease: false
-
-      - name: Create Compliance Benchmarks ConfigMap
-        uses: steebchen/kubectl@master
-        with:
-          args: create configmap datadog-compliance-benchmarks --dry-run -o yaml --from-file=./compliance/containers > ./datadog-compliance-benchmarks.yaml
-
-      - name: Create Runtime Security Policies ConfigMap
-        uses: steebchen/kubectl@master
-        with:
-          args: create configmap datadog-runtime-policies --dry-run -o yaml --from-file=./runtime > ./datadog-runtime-policies.yaml
-
-      - name: Upload Compliance Benchmarks ConfigMap
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./datadog-compliance-benchmarks.yaml
-          asset_name: datadog-compliance-benchmarks.yaml
-          asset_content_type: application/yaml
-
-      - name: Upload Runtime Security Policies ConfigMap
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./datadog-runtime-policies.yaml
-          asset_name: datadog-runtime-policies.yaml
-          asset_content_type: application/yaml
+          files: |
+            datadog-compliance-benchmarks.yaml
+            datadog-runtime-policies.yaml


### PR DESCRIPTION
### What does this PR do?

The current `release` Github Action is simply not working because it uses:
- outdated (repo archived) actions (related to release creation and asset upload)
- unpinned action (kubectl) that changed upstream
This PR fixes this issues

### Additional Notes

- The Tag name extraction is done manually when it was done automatically by the action before
- Take a look in the fork at the different workflow runs, and the different releases generated
