### PR TITLE
[CMCW-1136] Regenerate runtime policy file after script update

### DIFF
--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -1,5 +1,5 @@
 # IMPORTANT: Edits to this file will not be reflected in the Datadog App and will be overwritten with new policy file downloads. Please modify rules in the Datadog App for full functionality.
-version: 1.4.2
+version: 1.4.3
 macros:
   - id: APT_PROCESSES
     expression: '["/usr/bin/unattended-upgrade", "/usr/bin/apt"]'


### PR DESCRIPTION
### What does this PR do?
Update runtime policy file to include a comment that warns users to not modify the file directly (regenerated from script update, see https://github.com/DataDog/security-monitoring/pull/573).

[Jira link](https://datadoghq.atlassian.net/browse/CMCW-1136)

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
