### PR TITLE
[SECMON][CWS][SEC-3289]Adopt a consistent naming conventions for all CWS related products

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           command: create configmap datadog-compliance-benchmarks --dry-run=client -o yaml --from-file=./compliance/containers > ./datadog-compliance-benchmarks.yaml
 
-      - name: Create Runtime Security Policies ConfigMap
+      - name: Create Workload Security Policies ConfigMap
         uses: steebchen/kubectl@v2.0.0
         with:
           command: create configmap datadog-runtime-policies --dry-run=client -o yaml --from-file=./runtime > ./datadog-runtime-policies.yaml
@@ -33,7 +33,7 @@ jobs:
           name: Release ${{ steps.tag_name_extractor.outputs.TAG_NAME }}
           body: |
             Changes in this Release
-            - Updated compliance benchmarks and runtime security policies for Datadog Security Agent.
+            - Updated compliance benchmarks and workload security policies for Datadog Security Agent.
           draft: false
           prerelease: false
           files: |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Security Agent Rules & Policies
-This repository hosts Datadog-curated rules & policies for the security agent. There are two main types: [Compliance Policies](#compliance-policies) and [Runtime Security Rules](#runtime-security-rules).
+This repository hosts Datadog-curated rules & policies for the security agent. There are two main types: [Compliance Policies](#compliance-policies) and [Workload Security Rules](#workload-security-rules).
 
 ## Compliance Policies
 These policies, provided by Datadog, check configuration and state against specific compliance frameworks. Currently Datadog provides out of the box support for a number of CIS benchmarks. The Center for Internet Security (CIS) is a non-profit organization formed to "make the connected world a safer place by developing, validating, and promoting timely best practice solutions that help people, businesses, and governments protect themselves against pervasive cyber threats"[1](https://www.cisecurity.org/about-us/). These benchmarks are used through the security & compliance industries as a set of best practices.
@@ -10,7 +10,7 @@ These policies are provded by Datadog and map to the CIS Docker benchmarks. Dock
 ### CIS Kubernetes
 These policies are provided by Datadog and map to the CIS Kubernetes benchmarks. Kubernetes is "an open-source system for automating deployment, scaling, and management of containerized applications."[2](https://kubernetes.io/).
 
-## Runtime Security Rules
+## Workload Security Rules
 These rules probvided by Datadog collect runtime events from Linux hosts and containers. Out of the box rules are provided to collect events based on tactics and techniques from the MITRE ATT&CK framework[3](https://attack.mitre.org/). The types of events supported are:
 
 ### File Integrity Monitoring Events


### PR DESCRIPTION
### What does this PR do?

This PR is about renaming legacy names "runtime-security", "runtime_security" or "runtime security" into the more up to date "workload-security", "workload_security" or "workload security" names. 

Here is the link for the associated jira ticket : [Jira](https://datadoghq.atlassian.net/jira/software/c/projects/SEC/boards/1423?modal=detail&selectedIssue=SEC-3236)

### Motivation

This is for adopting an homogeneous naming convention across all the CWS related products/repositories


