### PR TITLE
[CWS] Update policy to v1.9.1

### DIFF
--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -1,5 +1,5 @@
 # IMPORTANT: Edits to this file will not be reflected in the Datadog App and will be overwritten with new policy file downloads. Please modify rules in the Datadog App for full functionality.
-version: 1.9.0
+version: 1.9.1
 macros:
   - id: APP_PACKAGE_MANAGERS
     description: Package managers
@@ -427,7 +427,7 @@ rules:
       container.id == "" && exec.args not in [ ~"*localhost*", ~"*127.0.0.1*", ~"*motd.ubuntu.com*" ]
   - id: net_util_exfiltration
     description: Exfiltration attempt via network utility
-    expression: "exec.comm in HTTP_UTILS && \nexec.args_options in [ ~\"post-file=*\", ~\"post-data=*\", \"X=POST\", \"request=POST\", ~\"upload-file=*\", ~\"F=file*\"] &&\nexec.args not in [~\"*localhost*\", ~\"*127.0.0.1*\"]"
+    expression: "exec.comm in HTTP_UTILS && \nexec.args_options in [ ~\"post-file=*\", ~\"post-data=*\", ~\"T=*\", ~\"d=@*\", ~\"upload-file=*\", ~\"F=file*\"] &&\nexec.args not in [~\"*localhost*\", ~\"*127.0.0.1*\"]"
   - id: net_util_in_container
     description: A network utility was executed in a container
     expression: |-


### PR DESCRIPTION
### What does this PR do?

Sync with internal repo. Improving the `net_util_exfiltration` rule.
