### PR TITLE
[CSPM] Fix RHEL 7 and 8 CIS Benchmark versions

### DIFF
--- a/compliance/containers/cis-rhel7-3.1.1.yaml
+++ b/compliance/containers/cis-rhel7-3.1.1.yaml
@@ -2,7 +2,7 @@ schema:
   version: 1.0.0
 name: CIS Red Hat Enterprise Linux 7 Benchmark for Level 1 - Server
 framework: cis-rhel7
-version: 1.0.0
+version: 3.1.1
 rules:
   - id: xccdf_org.ssgproject.content_rule_account_disable_post_pw_expiration
     description: Set Account Expiration Following Inactivity

--- a/compliance/containers/cis-rhel8-2.0.0.yaml
+++ b/compliance/containers/cis-rhel8-2.0.0.yaml
@@ -2,7 +2,7 @@ schema:
   version: 1.0.0
 name: CIS Red Hat Enterprise Linux 8 Benchmark for Level 1 - Server
 framework: cis-rhel8
-version: 1.0.0
+version: 2.0.0
 rules:
   - id: xccdf_org.ssgproject.content_rule_account_disable_post_pw_expiration
     description: Set Account Expiration Following Inactivity


### PR DESCRIPTION
### What does this PR do?

This change fixes RHEL 7 and 8 CIS Benchmark versions.

Here are the versions of the Linux CIS Benchmarks we use:

```
cis-rhel7      Red Hat Linux 7 Benchmark   v3.1.1 2021-05-21
cis-rhel8      Red Hat Linux 8 Benchmark   v2.0.0 2022-02-23
cis-rhel9      Red Hat Linux 9 Benchmark   v1.0.0 2022-11-28
cis-ubuntu2004 Ubuntu 20.04 LTS Benchmark  v1.0.0 2020-07-21
cis-ubuntu2204 Ubuntu 22.04 LTS Benchmark  v1.0.0 2022-08-30
cis-amzn2      Amazon Linux 2 Benchmark    v1.0.0 2019-04-19
cis-al2023     Amazon Linux 2023 Benchmark v1.0.0 2023-03-07
```