### PR TITLE
[CSPM] Disable content_rule_file_permissions_ungroupowned rule

### DIFF
--- a/compliance/containers/cis-rhel7-3.1.1.yaml
+++ b/compliance/containers/cis-rhel7-3.1.1.yaml
@@ -941,14 +941,6 @@ rules:
           name: ssg-rhel7-ds-1.2.xml.bz2
           profile: xccdf_org.ssgproject.content_profile_cis_server_l1
           rule: xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key
-  - id: xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned
-    description: Ensure All Files Are Owned by a Group
-    filters: *id001
-    input:
-      - xccdf:
-          name: ssg-rhel7-ds-1.2.xml.bz2
-          profile: xccdf_org.ssgproject.content_profile_cis_server_l1
-          rule: xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned
   - id: xccdf_org.ssgproject.content_rule_file_permissions_user_cfg
     description: Verify /boot/grub2/user.cfg Permissions
     filters: *id001

--- a/compliance/containers/cis-rhel8-2.0.0.yaml
+++ b/compliance/containers/cis-rhel8-2.0.0.yaml
@@ -1013,14 +1013,6 @@ rules:
           name: ssg-rhel8-ds-1.2.xml.bz2
           profile: xccdf_org.ssgproject.content_profile_cis_server_l1
           rule: xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key
-  - id: xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned
-    description: Ensure All Files Are Owned by a Group
-    filters: *id001
-    input:
-      - xccdf:
-          name: ssg-rhel8-ds-1.2.xml.bz2
-          profile: xccdf_org.ssgproject.content_profile_cis_server_l1
-          rule: xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned
   - id: xccdf_org.ssgproject.content_rule_file_permissions_user_cfg
     description: Verify /boot/grub2/user.cfg Permissions
     filters: *id001

--- a/compliance/containers/cis-rhel9-1.0.0.yaml
+++ b/compliance/containers/cis-rhel9-1.0.0.yaml
@@ -1013,14 +1013,6 @@ rules:
           name: ssg-rhel9-ds-1.2.xml.bz2
           profile: xccdf_org.ssgproject.content_profile_cis_server_l1
           rule: xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key
-  - id: xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned
-    description: Ensure All Files Are Owned by a Group
-    filters: *id001
-    input:
-      - xccdf:
-          name: ssg-rhel9-ds-1.2.xml.bz2
-          profile: xccdf_org.ssgproject.content_profile_cis_server_l1
-          rule: xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned
   - id: xccdf_org.ssgproject.content_rule_file_permissions_user_cfg
     description: Verify /boot/grub2/user.cfg Permissions
     filters: *id001

--- a/compliance/containers/cis-ubuntu2004-1.0.0.yaml
+++ b/compliance/containers/cis-ubuntu2004-1.0.0.yaml
@@ -893,14 +893,6 @@ rules:
           name: ssg-ubuntu2004-ds-1.2.xml.bz2
           profile: xccdf_org.ssgproject.content_profile_cis_level1_server
           rule: xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key
-  - id: xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned
-    description: Ensure All Files Are Owned by a Group
-    filters: *id001
-    input:
-      - xccdf:
-          name: ssg-ubuntu2004-ds-1.2.xml.bz2
-          profile: xccdf_org.ssgproject.content_profile_cis_level1_server
-          rule: xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned
   - id: xccdf_org.ssgproject.content_rule_gid_passwd_group_same
     description: All GIDs referenced in /etc/passwd must be defined in /etc/group
     filters: *id001

--- a/compliance/containers/cis-ubuntu2204-1.0.0.yaml
+++ b/compliance/containers/cis-ubuntu2204-1.0.0.yaml
@@ -1061,14 +1061,6 @@ rules:
           name: ssg-ubuntu2204-ds-1.2.xml.bz2
           profile: xccdf_org.ssgproject.content_profile_cis_level1_server
           rule: xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key
-  - id: xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned
-    description: Ensure All Files Are Owned by a Group
-    filters: *id001
-    input:
-      - xccdf:
-          name: ssg-ubuntu2204-ds-1.2.xml.bz2
-          profile: xccdf_org.ssgproject.content_profile_cis_level1_server
-          rule: xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned
   - id: xccdf_org.ssgproject.content_rule_file_permissions_var_log_audit
     description: System Audit Logs Must Have Mode 0640 or Less Permissive
     filters: *id001


### PR DESCRIPTION
### What does this PR do?

This change disables the `xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned` rule, since it could allocate a large amount of memory on large file systems.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
