### PR TITLE
[CSM-T] Update policy to v1.19.1

### DIFF
--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -1,5 +1,5 @@
 # IMPORTANT: Edits to this file will not be reflected in the Datadog App and will be overwritten with new policy file downloads. Please modify rules in the Datadog App for full functionality.
-version: 1.19.0
+version: 1.19.1
 macros:
   - id: APP_PACKAGE_MANAGERS
     description: Package managers


### PR DESCRIPTION
### What does this PR do?

Syncing policy versions after auto-suppression format change.
