### PR TITLE
fix `suspicious_dll_write` agent rule

### DIFF
--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -1,5 +1,5 @@
 # IMPORTANT: Edits to this file will not be reflected in the Datadog App and will be overwritten with new policy file downloads. Please modify rules in the Datadog App for full functionality.
-version: 1.26.0
+version: 1.26.1
 macros:
   - id: APP_PACKAGE_MANAGERS
     expression: '["pip3", "pip", "npm"]'
@@ -1496,7 +1496,7 @@ rules:
       - os == "linux"
   - id: suspicious_dll_write
     description: Dll written to a suspicious directory
-    expression: create.file.name =~ "*.dll" && create.file.path !~ "C:\\Windows\\System32\\*"
+    expression: create.file.name =~ "*.dll" && create.file.path !~ "\Device\*\Windows\System32\**"
     filters:
       - os == "windows"
   - id: suspicious_ntdsutil_usage


### PR DESCRIPTION
### What does this PR do?

This PR fixes the path and format of the `suspicious_dll_write` to match recent glob changes on windows.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
