### PR TITLE
[CWS] fix suspicious dll rule with recent device path renaming

### DIFF
--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -1496,7 +1496,7 @@ rules:
       - os == "linux"
   - id: suspicious_dll_write
     description: Dll written to a suspicious directory
-    expression: create.file.name =~ "*.dll" && create.file.path !~ "\Device\*\Windows\System32\**"
+    expression: create.file.name =~ "*.dll" && create.file.device_path !~ "\Device\*\Windows\System32\**"
     filters:
       - os == "windows"
   - id: suspicious_ntdsutil_usage


### PR DESCRIPTION
### What does this PR do?

This PR fixes the `suspicious_dll_write` in relation to recent device path field renaming

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
