### PR TITLE
Update Leaky Vessels rule

### DIFF
--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -1,5 +1,5 @@
 # IMPORTANT: Edits to this file will not be reflected in the Datadog App and will be overwritten with new policy file downloads. Please modify rules in the Datadog App for full functionality.
-version: 1.28.0
+version: 1.28.1
 macros:
   - id: APP_PACKAGE_MANAGERS
     description: Package managers
@@ -1188,7 +1188,7 @@ rules:
       - os == "windows"
   - id: runc_leaky_fd
     description: The container breakout CVE-2024-21626 was successful
-    expression: chdir.file.path == "/sys/fs/cgroup" && chdir.file.filesystem in ["cgroup", "cgroup2"] && process.file.name =~ "runc.*"
+    expression: chdir.file.path == "/sys/fs/cgroup" && chdir.syscall.path =~ "/proc/self/fd/*" && process.file.name =~ "runc.*"
     filters:
       - os == "linux"
   - id: runc_modification


### PR DESCRIPTION
### What does this PR do?

Updates the policy to v1.28.1 which includes a change to the runc leaky vessels rule

### Motivation

Increasing rule confidence