### PR TITLE
Update runtime policy to v1.29.1

### DIFF
--- a/runtime/default.policy
+++ b/runtime/default.policy
@@ -1,5 +1,5 @@
 # IMPORTANT: Edits to this file will not be reflected in the Datadog App and will be overwritten with new policy file downloads. Please modify rules in the Datadog App for full functionality.
-version: 1.29.0
+version: 1.29.1
 macros:
   - id: APP_PACKAGE_MANAGERS
     description: Package managers
@@ -1185,7 +1185,7 @@ rules:
       - os == "windows"
   - id: runc_leaky_fd
     description: The container breakout CVE-2024-21626 was successful
-    expression: chdir.syscall.path =~ "/proc/self/fd/*" && process.file.name =~ "runc.*"
+    expression: chdir.syscall.path =~ "/proc/self/fd/*" && chdir.file.path == "/sys/fs/cgroup" && process.file.name =~ "runc.*"
     filters:
       - os == "linux"
   - id: runc_modification


### PR DESCRIPTION
### What does this PR do?

Updates rule `runc_leaky_fd`
