### PR TITLE
[CSPM] Sync docker policies

### DIFF
--- a/compliance/containers/cis-docker-1.2.0-5.31.rego
+++ b/compliance/containers/cis-docker-1.2.0-5.31.rego
@@ -1,7 +1,18 @@
 package datadog
 
+import future.keywords.in
+
+allow_list_container_images = {
+	"datadog/agent",
+	"datadog/cluster-agent",
+}
+
 invalid_mount(c) {
 	c.inspect.Mounts[_].Source == "/var/run/docker.sock"
+}
+
+valid_container(c) {
+	c.image_repo in allow_list_container_images
 }
 
 valid_container(c) {


### PR DESCRIPTION
Syncing the last change made to Docker policies made to allow list specific containers for rule 5.31 of Docker benchmarks.