### PR TITLE
Remove Docs Team as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,4 +13,4 @@
 /runtime                        @DataDog/agent-security
 
 # Documentation
-*.md                            @DataDog/documentation @DataDog/agent-security
+*.md                            @DataDog/agent-security


### PR DESCRIPTION
### What does this PR do?

Removes Docs as CODEOWNERS from the repo.

### Motivation

As part of a project to reduce courtesy reviews, the Docs Team is limiting CODEOWNERS entries to repos that single-source content into the docs site or where our review is critical. We’re still happy to review content if you reach out to us directly.

### Additional Notes

Anything else we should know when reviewing?
